### PR TITLE
Refactoring search with RwLock and other improvements

### DIFF
--- a/app/core/src/search/disk.rs
+++ b/app/core/src/search/disk.rs
@@ -7,7 +7,7 @@ use std::ffi::OsStr;
 use std::fs::read_to_string;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use walkdir::WalkDir;
 
@@ -23,7 +23,6 @@ impl Ord for ResearchResult {
         self.priority.cmp(&other.priority)
     }
 }
-struct Disk {}
 
 /// Storing the results incrementally found in the search index
 #[derive(Clone)]
@@ -81,20 +80,26 @@ impl OrderedResults {
 
 #[derive(Debug)]
 pub struct DiskResearcher {
-    markdown_paths_set: Arc<Mutex<Vec<String>>>,
+    /// The list of all paths to Markdown files found
+    /// Use a RwLock to make searches more optimized during index construction
+    markdown_paths_vec: Arc<RwLock<Vec<String>>>,
     /// Each heading found will have an entry with a vector of files where it was found.
-    title_map: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    /// Use a RwLock to make searches more optimized during index construction
+    title_map: Arc<RwLock<HashMap<String, Vec<String>>>>,
     base_path: PathBuf,
     max_nb_threads: usize,
     has_started: bool,
+    /// The progress counter counting the number of markdown paths where the titles
+    /// have been extracted and saved
+    /// Use a Mutex because writes will probably be more frequent than reads
     progress_counter: Arc<Mutex<usize>>,
 }
 
 impl DiskResearcher {
     pub fn new(path: String) -> Self {
         Self {
-            markdown_paths_set: Arc::new(Mutex::new(Vec::new())),
-            title_map: Arc::new(Mutex::new(HashMap::new())),
+            markdown_paths_vec: Arc::new(RwLock::new(Vec::new())),
+            title_map: Arc::new(RwLock::new(HashMap::new())),
             base_path: PathBuf::from(path),
             max_nb_threads: num_cpus::get(),
             has_started: false,
@@ -142,7 +147,8 @@ impl Researcher for DiskResearcher {
     fn start(&mut self) {
         self.has_started = true;
 
-        //Get all paths. We have to accept the directory at first otherwise their content would be ignored
+        // Get all paths by searching for Marddown files on disk
+        // We have to accept the directory at first otherwise their content would be ignored
         let markdown_paths: Vec<String> = WalkDir::new(&self.base_path)
             .into_iter()
             .filter_entry(|entry| {
@@ -158,47 +164,54 @@ impl Researcher for DiskResearcher {
                     .to_string()
             })
             .collect();
-        let all_paths: Vec<_> = markdown_paths.clone();
+        // Save the result into the markdown_paths_set
         {
-            let mut map = self.markdown_paths_set.lock().unwrap();
+            let mut map = self.markdown_paths_vec.write().unwrap();
             *map = markdown_paths.clone();
         }
 
-        if all_paths.is_empty() {
+        if markdown_paths.is_empty() {
             return;
         }
-        let chunk_size = if (all_paths.len()) < self.max_nb_threads {
+        let chunk_size = if (markdown_paths.len()) < self.max_nb_threads {
             1 //This means we have more thread than the number of files
         } else {
-            all_paths.len().div_ceil(self.max_nb_threads)
+            markdown_paths.len().div_ceil(self.max_nb_threads)
         };
 
-        for chunk in all_paths.chunks(chunk_size) {
-            let chunk = chunk.to_vec(); // copy chunk
+        // We iterate on chunks and do copy of it, because we need to have a local version on each
+        // thread to iterate without needing to lock the RwLock to read each entry
+        // and potentially be blocked by writers threads during indexing
+        for chunk in markdown_paths.chunks(chunk_size) {
+            let local_chunk = chunk.to_vec(); // copy chunk
             let title_map = Arc::clone(&self.title_map);
             let counter = Arc::clone(&self.progress_counter);
 
-            //Create the thread to search for markdown in chunk
+            // Create the thread to search for markdown in chunk
             thread::spawn(move || {
-                //Local counter to avoid locking unlocking every loop.
+                // Local counter to avoid locking unlocking every loop.
                 let mut local_counter = 0;
-                for path in chunk {
+                for path in local_chunk {
                     let content = read_to_string(&path).unwrap_or_default();
+                    // We found some titles, let's insert them or add their paths to existing entries
                     let titles = DiskResearcher::extract_markdown_titles(&content);
                     {
-                        let mut map = title_map.lock().unwrap();
+                        let mut map = title_map.write().unwrap();
                         for title in titles {
                             map.entry(title).or_default().push(path.clone())
                         }
                     }
                     local_counter += 1;
+                    // We update the shared counter not at each iteration
                     if local_counter == 10 {
-                        let mut global_counter = counter.lock().unwrap();
-                        *global_counter += 10;
+                        {
+                            let mut global_counter = counter.lock().unwrap();
+                            *global_counter += 10;
+                        }
                         local_counter = 0;
                     }
                 }
-                //If final counter is not 0 then we need to add the rest
+                // If final counter is not 0 then we need to add the rest
                 // to the total to have the real total when finished.
                 if local_counter != 0 {
                     let mut global_counter = counter.lock().unwrap();
@@ -207,9 +220,10 @@ impl Researcher for DiskResearcher {
             });
         }
     }
+
     /// Ask about the progress, from 0 to 100 percent of research
     fn progress(&self) -> Progress {
-        let total = self.markdown_paths_set.lock().unwrap().len();
+        let total = self.markdown_paths_vec.read().unwrap().len();
         if total == 0 {
             return Progress(0);
         }
@@ -225,7 +239,7 @@ impl Researcher for DiskResearcher {
         limit: u8,
         sender: Option<Sender<ResearchResult>>,
     ) -> Vec<ResearchResult> {
-        let map = self.title_map.lock().unwrap().clone();
+        let map = self.title_map.read().unwrap().clone();
 
         let results: Arc<Mutex<OrderedResults>> = Arc::new(Mutex::new(OrderedResults::new(sender)));
         let headings: Vec<_> = map.into_iter().collect();
@@ -238,16 +252,18 @@ impl Researcher for DiskResearcher {
         };
 
         let query = raw.to_lowercase();
+        // Each thread will inspect part of the titles index to search
+        // for matches of the given query. Again we use a local copy.
         for tuples_chunk in headings.chunks(chunk_size) {
             let tuples = tuples_chunk.to_vec(); // copy chunk
             let results = Arc::clone(&results);
 
-            let query = query.clone();
+            let local_query = query.clone();
             let handle = thread::spawn(move || {
                 let mut matcher = Matcher::new(Config::DEFAULT);
                 // Search in parallel into the headings
                 let pattern = Pattern::new(
-                    &query,
+                    &local_query,
                     CaseMatching::Ignore,
                     Normalization::Smart,
                     AtomKind::Fuzzy,
@@ -273,7 +289,7 @@ impl Researcher for DiskResearcher {
         }
 
         // Search in parallel in the path as well and attibute higher priority
-        let file_list = self.markdown_paths_set.lock().unwrap().clone();
+        let file_list = self.markdown_paths_vec.read().unwrap().clone();
         let mut matcher = Matcher::new(Config::DEFAULT.match_paths());
         // Search in parallel into the headings
         let pattern = Pattern::new(
@@ -304,8 +320,8 @@ impl Researcher for DiskResearcher {
 
     fn stats(&self) -> IndexStat {
         IndexStat {
-            headings_count: self.title_map.lock().unwrap().len(),
-            markdown_paths_count: self.markdown_paths_set.lock().unwrap().len(),
+            headings_count: self.title_map.read().unwrap().len(),
+            markdown_paths_count: self.markdown_paths_vec.read().unwrap().len(),
         }
     }
 }
@@ -317,8 +333,8 @@ fn test_that_file_are_found() {
     //Wait for completion
     thread::sleep(std::time::Duration::from_secs(1));
 
-    assert!(!search.markdown_paths_set.lock().unwrap().is_empty());
-    for path in search.markdown_paths_set.lock().unwrap().iter() {
+    assert!(!search.markdown_paths_vec.read().unwrap().is_empty());
+    for path in search.markdown_paths_vec.read().unwrap().iter() {
         assert!(path.ends_with(".md"));
     }
 }


### PR DESCRIPTION
That's a proposal of a refactoring with RwLock as it makes more sense than a Mutex. This also removes some clones and add comments on the strategy. There is also a bunch of renaming.

By the way the basic HPC benchmark gives us an improvement of 129ms to 88ms.