### PR TITLE
Minor refactorings to improve responsiveness and coherence

### DIFF
--- a/app/core/src/preview/comrak.rs
+++ b/app/core/src/preview/comrak.rs
@@ -10,9 +10,6 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use tree_sitter_loader::Loader;
 
-static TREE_SITTER_GRAMMARS_FOLDER_VIA_ENV: Lazy<Option<String>> =
-    Lazy::new(|| std::env::var("TREE_SITTER_GRAMMARS_FOLDER").ok());
-
 pub struct ComrakParser {
     manager: TreeSitterGrammarsManager,
 }
@@ -21,13 +18,7 @@ impl ComrakParser {
     /// Create a new ComrakParser with a default grammars folder or use the
     /// TREE_SITTER_GRAMMARS_FOLDER environment variable if defined
     pub fn new() -> Result<Self, String> {
-        let manager = match &*TREE_SITTER_GRAMMARS_FOLDER_VIA_ENV {
-            Some(folder) => {
-                TreeSitterGrammarsManager::new_with_grammars_folder(PathBuf::from(folder.clone()))
-            }
-            None => TreeSitterGrammarsManager::new(),
-        }?;
-
+        let manager = TreeSitterGrammarsManager::new()?;
         Ok(ComrakParser { manager })
     }
 

--- a/app/core/src/preview/tree_sitter_grammars.rs
+++ b/app/core/src/preview/tree_sitter_grammars.rs
@@ -23,31 +23,31 @@ pub struct TreeSitterGrammarsManager {
     final_grammars_folder: PathBuf,
 }
 
+static TREE_SITTER_GRAMMARS_FOLDER_VIA_ENV: Lazy<Option<PathBuf>> = Lazy::new(|| {
+    std::env::var("TREE_SITTER_GRAMMARS_FOLDER")
+        .ok()
+        .map(PathBuf::from)
+});
+
 impl TreeSitterGrammarsManager {
     /// Create a new manager with a loader that needs a Tree-Sitter LIBDIR
     pub fn new() -> Result<Self, String> {
-        let loader = Loader::new().map_err(|e| e.to_string())?;
-
-        /// Use the DATA HOME strategy to determine the base folder grammars and cloned and managed
+        /// Use the DATA HOME strategy to determine the base folder grammars
         /// on Linux it will be under ~/.local/share/tree-sitter-grammars
         static DEFAULT_TREE_SITTER_GRAMMARS_FOLDER: Lazy<PathBuf> = Lazy::new(|| {
-            let folder = etcetera::choose_app_strategy(AppStrategyArgs {
+            etcetera::choose_app_strategy(AppStrategyArgs {
                 app_name: "tree-sitter-grammars".to_string(),
                 ..Default::default()
             })
             .unwrap() // only in case it couldn't determine the home the directory,
             // in this case we don't know where to put these grammars and the only option is to panic
             .data_dir()
-            .to_path_buf();
-            if !folder.exists() {
-                let _ = create_dir(&folder);
-            }
-            folder
+            .to_path_buf()
         });
-        Ok(TreeSitterGrammarsManager {
-            loader,
-            final_grammars_folder: DEFAULT_TREE_SITTER_GRAMMARS_FOLDER.clone(),
-        })
+        let final_folder: &PathBuf = (*TREE_SITTER_GRAMMARS_FOLDER_VIA_ENV)
+            .as_ref()
+            .unwrap_or(&*DEFAULT_TREE_SITTER_GRAMMARS_FOLDER);
+        Self::new_with_grammars_folder(final_folder.clone())
     }
 
     /// Create a manager by specifying another folder instead of DEFAULT_TREE_SITTER_GRAMMARS_FOLDER
@@ -56,6 +56,14 @@ impl TreeSitterGrammarsManager {
         another_grammars_folder: PathBuf,
     ) -> Result<Self, String> {
         let loader = Loader::new().map_err(|e| e.to_string())?;
+        if !another_grammars_folder.exists() {
+            let _ = create_dir(&another_grammars_folder).map_err(|e| {
+                format!(
+                    "Coudln't create folder for grammars at {:?} because of {}",
+                    another_grammars_folder, e
+                )
+            });
+        }
         Ok(TreeSitterGrammarsManager {
             loader,
             final_grammars_folder: another_grammars_folder,

--- a/app/src-tauri/src/commands/grammars.rs
+++ b/app/src-tauri/src/commands/grammars.rs
@@ -20,7 +20,7 @@ pub struct GrammarState {
 }
 
 #[tauri::command]
-pub fn get_grammars_list() -> Result<Vec<GrammarState>, String> {
+pub async fn get_grammars_list() -> Result<Vec<GrammarState>, String> {
     let mut manager = TreeSitterGrammarsManager::new()?;
     let list = manager.list_installed_langs()?;
     let installed_map: HashSet<String> = HashSet::from_iter(list);
@@ -43,8 +43,8 @@ pub fn get_grammars_list() -> Result<Vec<GrammarState>, String> {
     Ok(result)
 }
 
-#[tauri::command(async)]
-pub fn install_grammar(id: &str) -> Result<(), String> {
+#[tauri::command]
+pub async fn install_grammar(id: &str) -> Result<(), String> {
     let mut manager = TreeSitterGrammarsManager::new()?;
     let link = PROPOSED_GRAMMAR_SOURCES
         .get(id)
@@ -53,8 +53,8 @@ pub fn install_grammar(id: &str) -> Result<(), String> {
     Ok(())
 }
 
-#[tauri::command(async)]
-pub fn remove_grammar(id: &str) -> Result<(), String> {
+#[tauri::command]
+pub async fn remove_grammar(id: &str) -> Result<(), String> {
     let mut manager = TreeSitterGrammarsManager::new()?;
     let link = PROPOSED_GRAMMAR_SOURCES
         .get(id)
@@ -63,8 +63,8 @@ pub fn remove_grammar(id: &str) -> Result<(), String> {
     Ok(())
 }
 
-#[tauri::command(async)]
-pub fn grammars_folder() -> Result<String, String> {
+#[tauri::command]
+pub async fn grammars_folder() -> Result<String, String> {
     let manager = TreeSitterGrammarsManager::new()?;
     Ok(manager
         .get_grammars_folder()

--- a/app/src-tauri/src/commands/home.rs
+++ b/app/src-tauri/src/commands/home.rs
@@ -6,7 +6,7 @@ pub struct AppInfo {
 }
 
 #[tauri::command]
-pub fn get_app_info() -> AppInfo {
+pub async fn get_app_info() -> AppInfo {
     AppInfo {
         version: env!("CARGO_PKG_VERSION").to_owned(),
     }

--- a/app/src-tauri/src/commands/preview.rs
+++ b/app/src-tauri/src/commands/preview.rs
@@ -5,7 +5,7 @@ use dme_core::{markdown_to_highlighted_html, preview::preview::Html};
 #[tauri::command]
 /// Open given Markdown file or the default one provided as argument
 /// or none otherwise
-pub fn open_markdown_file(mut path: String) -> Result<Option<Html>, String> {
+pub async fn open_markdown_file(mut path: String) -> Result<Option<Html>, String> {
     println!("{path:?}");
     if path.is_empty() {
         path = {

--- a/app/src-tauri/src/commands/search.rs
+++ b/app/src-tauri/src/commands/search.rs
@@ -10,7 +10,7 @@ use tauri::{AppHandle, Emitter, Manager};
 use crate::AppData;
 
 #[tauri::command]
-pub fn run_search(app: AppHandle, search: String) -> Result<String, String> {
+pub async fn run_search(app: AppHandle, search: String) -> Result<String, String> {
     thread::spawn(move || {
         if let Some(state) = app.try_state::<AppData>() {
             println!("Searching {search} ");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2,37 +2,15 @@ mod commands;
 
 use crate::commands::grammars::get_grammars_list;
 use crate::commands::search::run_search;
-use std::{
-    collections::{HashMap, HashSet},
-    env::current_dir,
-    path::{Path, PathBuf},
-    sync::{
-        mpsc::{self, Receiver},
-        Arc, Mutex,
-    },
-    thread::{self, sleep},
-    time::{Duration, Instant},
-};
+use std::sync::{mpsc::Receiver, Mutex};
 
 use commands::{
     grammars::{grammars_folder, install_grammar, remove_grammar},
     home::get_app_info,
     preview::open_markdown_file,
 };
-use dme_core::{
-    markdown_to_highlighted_html,
-    preview::{
-        preview::Html, proposed_grammars::PROPOSED_GRAMMAR_SOURCES,
-        tree_sitter_grammars::TreeSitterGrammarsManager,
-    },
-    search::{
-        disk::DiskResearcher,
-        search::{Progress, ResearchResult, Researcher},
-    },
-};
-use serde::Serialize;
-use tauri::{AppHandle, Emitter};
-use tauri::{Builder, Manager};
+use dme_core::search::{disk::DiskResearcher, search::ResearchResult};
+use tauri::Manager;
 
 struct AppData {
     disk_researcher: Mutex<DiskResearcher>,


### PR DESCRIPTION
- move `TREE_SITTER_GRAMMARS_FOLDER_VIA_ENV` management in `TreeSitterGrammarsManager` to avoid incoherence when using TreeSitterGrammarsManager directly without comrak parser
- make all Tauri commands async to avoid blocking the UI