### PR TITLE
Image support

### DIFF
--- a/app/core/Cargo.lock
+++ b/app/core/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-highlight",
  "tree-sitter-loader",
+ "urlencoding",
  "walkdir",
 ]
 
@@ -1642,6 +1643,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/app/core/Cargo.toml
+++ b/app/core/Cargo.toml
@@ -30,6 +30,7 @@ toml = "0.8.23"
 nucleo-matcher = "0.3.1"
 ammonia = "4.1.0"
 maplit = "1.0.2"
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -1027,6 +1027,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-highlight",
  "tree-sitter-loader",
+ "urlencoding",
  "walkdir",
 ]
 
@@ -1790,6 +1791,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"
@@ -4015,6 +4022,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",
@@ -4758,6 +4766,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/app/src-tauri/src/commands/preview.rs
+++ b/app/src-tauri/src/commands/preview.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use dme_core::markdown_file_to_highlighted_html;
+use dme_core::preview::preview::ImageUrlRewriteMode;
 
 #[tauri::command]
 /// Open given Markdown file or the default one provided as argument
@@ -20,8 +21,16 @@ pub async fn open_markdown_file(mut path: String) -> Result<Option<String>, Stri
     if path.is_empty() {
         Ok(None)
     } else if PathBuf::from(&path).exists() {
+        let pwd: PathBuf = PathBuf::from(".");
+        let parent_path = PathBuf::from(path.clone())
+            .parent()
+            .unwrap_or_else(|| &pwd)
+            .to_string_lossy()
+            .to_string();
         Ok(Some(
-            markdown_file_to_highlighted_html(&path)?.to_safe_html_string(),
+            markdown_file_to_highlighted_html(&path)?
+                .set_image_rewrite(ImageUrlRewriteMode::TauriFullPath(parent_path))
+                .to_safe_html_string(),
         ))
     } else {
         Err(format!("File {path} doesn't exist !").to_string())

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost",
+            "csp": "default-src 'self' ipc: http://ipc.localhost; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost",
             "assetProtocol": {
                 "enable": true,
                 "scope": [

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
             }
         ],
         "security": {
-            "csp": "default-src 'self' ipc: http://ipc.localhost; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost",
+            "csp": "default-src 'self' ipc: http://ipc.localhost; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost https:;",
             "assetProtocol": {
                 "enable": true,
                 "scope": [

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -18,7 +18,14 @@
             }
         ],
         "security": {
-            "csp": null
+            "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost",
+            "assetProtocol": {
+                "enable": true,
+                "scope": [
+                    "$HOME/**",
+                    "/usr/**"
+                ]
+            }
         }
     },
     "bundle": {


### PR DESCRIPTION
This PR is adding support for image display, with a simple way to prefix images with an absolute URL. In the case of a Tauri dekstop app, an option allows to prefix with the absolute file path of the file, including the special `asset://` protocol.

It also changes the CSP of the desktop app to allow loading these images and avoid blocking inline CSS from tree-sitter.