### PR TITLE
Ajout de la licence MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) The DME Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Note: this is far ready to be fully usable for now, but if you want to install D
    sudo apt install /src-tauri/target/release/bundle/rpm/dme-0.1.0-1.x86_64.rpm
    ```
 
+### License
+The DME project is released under the [MIT license](LICENSE).
+
+---
+
 ## Project structure
 This is a cleaned overview of the project structure with a few comments.
 ```

--- a/app/core/Cargo.toml
+++ b/app/core/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "dme-core"
+license = "MIT"
 version = "0.1.0"
 description = "The core library of DME, backing up the CLI and Tauri app."
-authors = ["you"]
+authors = ["The DME Contributors"]
 edition = "2021"
 
 # Recommended configuration

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dme",
+  "license": "MIT",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "dme"
+license = "MIT"
 version = "0.1.0"
 description = "A Tauri App"
-authors = ["you"]
+authors = ["The DME Contributors"]
 edition = "2021"
 
 # Recommended configuration


### PR DESCRIPTION
Cette licence ne sera intégrée au projet qu’après avoir reçu la signature de l'accord "Publication du projet DME sous licence libre" et l'approbation des PRs ouvertes, par tous les membres du projet, ainsi que de la permission écrite de la HEIG-VD.
